### PR TITLE
Fix for kernel 5.14.x

### DIFF
--- a/apple-ib-als.c
+++ b/apple-ib-als.c
@@ -486,8 +486,8 @@ static int appleals_config_iio(struct appleals_device *als_dev)
 		return rc;
 	}
 
-	iio_trig = devm_iio_trigger_alloc(parent, "%s-dev%d", iio_dev->name,
-					  iio_dev->id);
+	iio_trig = devm_iio_trigger_alloc(parent, "%s-dev%d", 
+					  iio_dev->name);
 	if (!iio_trig)
 		return -ENOMEM;
 


### PR DESCRIPTION
I've not tested this on older kernels but it fixes the build error in apple-ib-als on 5.14.x