### PR TITLE
Fix compiler warning

### DIFF
--- a/apple-ib-als.c
+++ b/apple-ib-als.c
@@ -491,7 +491,7 @@ static int appleals_config_iio(struct appleals_device *als_dev)
 	iio_trig = devm_iio_trigger_alloc(parent, "%s-dev%d", iio_dev->name,
 					  iio_dev->id);
 	#else
-	iio_trig = devm_iio_trigger_alloc(parent, "%s-dev%d", 
+	iio_trig = devm_iio_trigger_alloc(parent, "%s-dev", 
 					  iio_dev->name);
 	#endif
 	if (!iio_trig)


### PR DESCRIPTION
In 5.14 and above, the iio_dev->id has been removed, which probably represented an int argument %d.

The error was :- `warning: format ‘%d’ expects a matching ‘int’ argument [-Wformat=]`