### PR TITLE
Make fnmode 2 be default

### DIFF
--- a/apple-ib-tb.c
+++ b/apple-ib-tb.c
@@ -98,8 +98,8 @@ static int appletb_tb_def_fn_mode = APPLETB_FN_MODE_INV;
 module_param_named(fnmode, appletb_tb_def_fn_mode, int, 0444);
 MODULE_PARM_DESC(fnmode, "Default Fn key mode:\n"
 			 "    0 - function-keys only\n"
-			 "    [1] - fn key switches from special to function-keys\n"
-			 "    2 - inverse of 1\n"
+			 "    1 - fn key switches from special to function-keys\n"
+			 "    [2] - inverse of 1\n"
 			 "    3 - special keys only\n"
 			 "    4 - escape key only");
 

--- a/apple-ib-tb.c
+++ b/apple-ib-tb.c
@@ -94,7 +94,7 @@ MODULE_PARM_DESC(dim_timeout, "Default touch bar dim timeout:\n"
 			      "    -1 - disable timeout (touch bar never dimmed)\n"
 			      "    [-2] - calculate timeout based on idle-timeout");
 
-static int appletb_tb_def_fn_mode = APPLETB_FN_MODE_NORM;
+static int appletb_tb_def_fn_mode = APPLETB_FN_MODE_INV;
 module_param_named(fnmode, appletb_tb_def_fn_mode, int, 0444);
 MODULE_PARM_DESC(fnmode, "Default Fn key mode:\n"
 			 "    0 - function-keys only\n"


### PR DESCRIPTION
Since touchbar has issues changing graphically, fnmode 2 seems to be the most reliable. Thus make it default.